### PR TITLE
display: refactor onboard display

### DIFF
--- a/src/main/scala/riscv/BCD2Segments.scala
+++ b/src/main/scala/riscv/BCD2Segments.scala
@@ -6,32 +6,32 @@ import chisel3.util._
 class BCD2Segments extends Module {
   val io = IO(new Bundle {
     val bcd = Input(UInt(4.W))
-    val segs = Output(UInt(7.W))
+    val segs = Output(UInt(8.W))
   })
 
   val bcd = io.bcd
-  val segs = Wire(UInt(7.W))
+  val segs = Wire(UInt(8.W))
 
   segs := MuxLookup(
     bcd,
     0xFF.U,
     Array(
-      0.U -> 0x01.U,
-      1.U -> 0x4F.U,
-      2.U -> 0x12.U,
-      3.U -> 0x06.U,
-      4.U -> 0x4C.U,
-      5.U -> 0x24.U,
-      6.U -> 0x20.U,
-      7.U -> 0x0F.U,
-      8.U -> 0x00.U,
-      9.U -> 0x04.U,
-      10.U -> 0x08.U,
-      11.U -> 0x60.U,
-      12.U -> 0x72.U,
-      13.U -> 0x42.U,
-      14.U -> 0x30.U,
-      15.U -> 0x38.U,
+      0.U -> "b10000001".U,
+      1.U -> "b11001111".U,
+      2.U -> "b10010010".U,
+      3.U -> "b10000110".U,
+      4.U -> "b11001100".U,
+      5.U -> "b10100100".U,
+      6.U -> "b10100000".U,
+      7.U -> "b10001111".U,
+      8.U -> "b10000000".U,
+      9.U -> "b10000100".U,
+      10.U -> "b00001000".U,
+      11.U -> "b00001000".U,
+      12.U -> "b00110001".U,
+      13.U -> "b01000010".U,
+      14.U -> "b00110000".U,
+      15.U -> "b00111000".U,
     )
   )
 

--- a/src/main/scala/riscv/OnboardDigitDisplay.scala
+++ b/src/main/scala/riscv/OnboardDigitDisplay.scala
@@ -5,26 +5,15 @@ import chisel3.util._
 
 class OnboardDigitDisplay extends Module {
   val io = IO(new Bundle {
-    val numbers = Input(UInt(16.W))
-
-    val segs = Output(UInt(7.W))
     val digit_mask = Output(UInt(4.W))
   })
 
-  val counter = RegInit(UInt(32.W), 0.U)
-  val index = RegInit(UInt(2.W), 0.U)
+  val counter = RegInit(UInt(16.W), 0.U)
+  val digit_mask = RegInit(UInt(4.W), "b0111".U)
 
-  when(counter === 50000.U) {
-    counter := 0.U
-    index := index + 1.U
-  }.otherwise {
-    counter := counter + 1.U
+  counter := counter + 1.U
+  when(counter === 0.U) {
+    digit_mask := (digit_mask << 1) + digit_mask(3)
   }
-
-  val seg_mux = Module(new SegmentMux)
-  seg_mux.io.index := index
-  seg_mux.io.numbers := io.numbers
-
-  io.segs := seg_mux.io.segs
-  io.digit_mask := seg_mux.io.digit_mask
+  io.digit_mask := digit_mask
 }

--- a/src/main/scala/riscv/SYSULogo.scala
+++ b/src/main/scala/riscv/SYSULogo.scala
@@ -1,0 +1,20 @@
+package riscv
+
+import chisel3._
+import chisel3.util._
+
+class SYSULogo extends Module {
+  val io = IO(new Bundle {
+    val digit_mask = Input(UInt(4.W))
+    val segs = Output(UInt(8.W))
+  })
+
+  io.segs := MuxLookup(
+    io.digit_mask,
+    "b00100100".U, // "b0111".U, "b1101".U -> S
+    Array(
+      "b1011".U -> "b01000100".U, // Y
+      "b1110".U -> "b01000001".U, // U
+    )
+  )
+}

--- a/src/main/scala/riscv/SegmentMux.scala
+++ b/src/main/scala/riscv/SegmentMux.scala
@@ -5,11 +5,9 @@ import chisel3.util._
 
 class SegmentMux extends Module {
   val io = IO(new Bundle {
-    val index = Input(UInt(2.W))
+    val digit_mask = Input(UInt(4.W))
     val numbers = Input(UInt(16.W))
-
-    val segs = Output(UInt(7.W))
-    val digit_mask = Output(UInt(4.W))
+    val segs = Output(UInt(8.W))
   })
 
 
@@ -19,17 +17,12 @@ class SegmentMux extends Module {
   bcd2segs.io.bcd := digit
   io.segs := bcd2segs.io.segs
   digit := MuxLookup(
-    io.index,
-    io.numbers(3, 0), // 0.U
+    io.digit_mask,
+    io.numbers(3, 0), // "b1110".U
     Array(
-      1.U -> io.numbers(7, 4),
-      2.U -> io.numbers(11, 8),
-      3.U -> io.numbers(15, 12)
+      "b1101".U -> io.numbers(7, 4),
+      "b1011".U -> io.numbers(11, 8),
+      "b0111".U -> io.numbers(15, 12)
     )
   )
-
-  val s0 = io.index(0).asBool()
-  val s1 = io.index(1).asBool()
-
-  io.digit_mask := Cat(!(s0 && s1), s0 || !s1, !s0 || s1, s0 || s1)
 }

--- a/vivado/basys3.xdc
+++ b/vivado/basys3.xdc
@@ -88,9 +88,8 @@ set_property PACKAGE_PIN W6 [get_ports io_segs[5]]
     set_property IOSTANDARD LVCMOS33 [get_ports io_segs[5]]
 set_property PACKAGE_PIN W7 [get_ports io_segs[6]]
     set_property IOSTANDARD LVCMOS33 [get_ports io_segs[6]]
-
-set_property PACKAGE_PIN V7 [get_ports io_dp]
-	set_property IOSTANDARD LVCMOS33 [get_ports io_dp]
+set_property PACKAGE_PIN V7 [get_ports io_segs[7]]
+	set_property IOSTANDARD LVCMOS33 [get_ports io_segs[7]]
 
 set_property PACKAGE_PIN U2 [get_ports {io_digit_mask[0]}]
 	set_property IOSTANDARD LVCMOS33 [get_ports {io_digit_mask[0]}]


### PR DESCRIPTION
重构了和数码管相关的一些代码，方便后面给七段数码管显示一些别的东西。
加了一个显示 SYSU 的 LOGO 的功能作为示例，原来该位置的 debug 输出用16个 LED 灯显示。
另外根据[手册](https://www.stepfpga.com/doc/_media/basys3_rm.pdf)，数码管的 DP 引脚也算在七段数码管里，因此调整了约束文件，把 DP 算为 io.segs[7]，也方便输出。
现在输出字母时小数点也会亮，方便区分一些相近的符号（例如字母 `S` 和数字 `5` ）。